### PR TITLE
We change entry point file extension to "js"

### DIFF
--- a/00 Boilerplate/readme.md
+++ b/00 Boilerplate/readme.md
@@ -149,7 +149,7 @@ npm install babel-core babel-loader babel-preset-es2015 --save-dev
    },
 
    entry: [
-     './main.ts',
+     './main.js',
      '../node_modules/bootstrap/dist/css/bootstrap.css'
    ],
    output: {


### PR DESCRIPTION
We change file extension because we migrate to ES6
