### PR TITLE
Fix: remove propTypes warning #17

### DIFF
--- a/08 Colorpicker/readme.md
+++ b/08 Colorpicker/readme.md
@@ -95,7 +95,7 @@ Let's start by defining only one slider to control the red component of a given 
         onChange={event =>
           props.onColorUpdated(
             {
-              red: event.target.value,
+              red: parseInt(event.target.value, 10),
               green: props.color.green,
               blue: props.color.blue,
             }
@@ -174,7 +174,7 @@ Let's start by defining only one slider to control the red component of a given 
         onChange={event =>
           props.onColorUpdated(
             {
-              red: event.target.value,
+              red: parseInt(event.target.value, 10),
               green: props.color.green,
               blue: props.color.blue,
             }
@@ -192,7 +192,7 @@ Let's start by defining only one slider to control the red component of a given 
           props.onColorUpdated(
             {
               red: props.color.red,
-              green: event.target.value,
+              green: parseInt(event.target.value, 10),
               blue: props.color.blue,
             }
           )
@@ -210,7 +210,7 @@ Let's start by defining only one slider to control the red component of a given 
             {
               red: props.color.red,
               green: props.color.green,
-              blue: event.target.value,
+              blue: parseInt(event.target.value, 10),
             }
           )
         }

--- a/08 Colorpicker/src/colorpicker.jsx
+++ b/08 Colorpicker/src/colorpicker.jsx
@@ -10,7 +10,7 @@ export const ColorPicker = props => (
       onChange={event =>
         props.onColorUpdated(
           {
-            red: event.target.value,
+            red: parseInt(event.target.value, 10),
             green: props.color.green,
             blue: props.color.blue,
           }
@@ -28,7 +28,7 @@ export const ColorPicker = props => (
         props.onColorUpdated(
           {
             red: props.color.red,
-            green: event.target.value,
+            green: parseInt(event.target.value, 10),
             blue: props.color.blue,
           }
         )
@@ -46,7 +46,7 @@ export const ColorPicker = props => (
           {
             red: props.color.red,
             green: props.color.green,
-            blue: event.target.value,
+            blue: parseInt(event.target.value, 10),
           }
         )
       }


### PR DESCRIPTION
Fix: remove propTypes warning because event.target.value contains strig but ColorDisplayer.props.color.* should be numbers Lemoncode/react-by-es6#17